### PR TITLE
Issues/277 support uiimage self scaling by dpi property

### DIFF
--- a/Source/Request+AlamofireImage.swift
+++ b/Source/Request+AlamofireImage.swift
@@ -77,7 +77,6 @@ extension DataRequest {
     ///
     /// - returns: An image response serializer.
     public class func imageResponseSerializer(
-        imageScale: CGFloat = DataRequest.imageScale,
         inflateResponseImage: Bool = true)
         -> DataResponseSerializer<Image>
     {
@@ -89,7 +88,7 @@ extension DataRequest {
             do {
                 try DataRequest.validateContentType(for: request, response: response)
 
-                let image = try DataRequest.image(from: data, withImageScale: imageScale)
+                let image = try DataRequest.image(from: data)
                 if inflateResponseImage { image.af_inflate() }
 
                 return .success(image)
@@ -121,8 +120,7 @@ extension DataRequest {
     ///
     /// - returns: The request.
     @discardableResult
-    public func responseImage(
-        imageScale: CGFloat = DataRequest.imageScale,
+    public func responseImage(      
         inflateResponseImage: Bool = true,
         queue: DispatchQueue? = nil,
         completionHandler: @escaping (DataResponse<Image>) -> Void)
@@ -131,7 +129,6 @@ extension DataRequest {
         return response(
             queue: queue,
             responseSerializer: DataRequest.imageResponseSerializer(
-                imageScale: imageScale,
                 inflateResponseImage: inflateResponseImage
             ),
             completionHandler: completionHandler
@@ -180,14 +177,13 @@ extension DataRequest {
 
     private class func serializeImage(
         from data: Data,
-        imageScale: CGFloat = DataRequest.imageScale,
         inflateResponseImage: Bool = true)
         -> UIImage?
     {
         guard data.count > 0 else { return nil }
 
         do {
-            let image = try DataRequest.image(from: data, withImageScale: imageScale)
+            let image = try DataRequest.image(from: data)
             if inflateResponseImage { image.af_inflate() }
 
             return image
@@ -196,7 +192,8 @@ extension DataRequest {
         }
     }
 
-    private class func image(from data: Data, withImageScale imageScale: CGFloat) throws -> UIImage {
+    private class func image(from data: Data) throws -> UIImage {
+      let imageScale = UIImage.af_imageScale(from: data) ?? DataRequest.imageScale
         if let image = UIImage.af_threadSafeImage(with: data, scale: imageScale) {
             return image
         }

--- a/Source/UIImage+AlamofireImage.swift
+++ b/Source/UIImage+AlamofireImage.swift
@@ -26,6 +26,7 @@
 
 import CoreGraphics
 import Foundation
+import ImageIO
 import UIKit
 
 // MARK: Initialization
@@ -33,6 +34,25 @@ import UIKit
 private let lock = NSLock()
 
 extension UIImage {
+    
+    /// Extract DPIHeight property from CFImageSource and return scale depend on it
+    ///
+    /// - parameter data: The data object containing the image data.
+    ///
+    /// - returns: A scale property based on image data 'DPIHeight' property (if exist)
+    public static func af_imageScale(from data: Data) -> CGFloat? {
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        let cfDict = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil)
+        guard let dpiUnsafeValue = CFDictionaryGetValue(cfDict, unsafeBitCast(kCGImagePropertyDPIHeight, to: UnsafeRawPointer.self)) else {
+            return nil
+        }
+        let dpi = unsafeBitCast(dpiUnsafeValue, to: CFNumber.self)
+        let dpiNumber = (dpi as NSNumber).floatValue
+        return CGFloat(dpiNumber) / CGFloat(72.0)
+    }
+    
     /// Initializes and returns the image object with the specified data in a thread-safe manner.
     ///
     /// It has been reported that there are thread-safety issues when initializing large amounts of images


### PR DESCRIPTION
Image DPI extracts from CFImageSource properties and imageScale implements based on DPIHeight. If that property hasn't setted, default UIScreen.main.scale using (like before)